### PR TITLE
add history days and timeout params to config file

### DIFF
--- a/cmd/scom/scom.conf
+++ b/cmd/scom/scom.conf
@@ -24,6 +24,17 @@
 #
 #tick=3
 
+# Job history tab view can show entries for number of days
+#  Default if unset = 7
+#  Min. value = 1
+#histdays=7
+
+# Job history tab command timeout (in seconds)
+# The call to sacct can take a lot of time depending on the number of entries in the DB
+#  Default if unset = 30
+#  Min. value = 1
+#histtimeout=30
+
 # Paths to required slurm commands
 # If some, or all of the following binaries reside in different directories, 
 # you can set their respective paths below:

--- a/cmd/scom/scom.go
+++ b/cmd/scom/scom.go
@@ -29,11 +29,18 @@ func main() {
 
 	var (
 		debugSet bool = false
+		args *cmdline.CmdArgs
 	)
 
 	fmt.Printf("Welcome to Slurm Commander!\n\n")
 
-	args, err := cmdline.NewCmdArgs()
+	cc := config.NewConfigContainer()
+	err := cc.GetConfig()
+	if err != nil {
+		log.Printf("ERROR: parsing config files: %s\n", err)
+	}
+
+	args, err = cmdline.NewCmdArgs(cc.HistDays, cc.HistTimeout)
 	if err != nil {
 		log.Fatalf("ERROR: parsing cmdline args: %s\n", err)
 	}
@@ -41,12 +48,6 @@ func main() {
 	if *args.Version {
 		version.DumpVersion()
 		os.Exit(0)
-	}
-
-	cc := config.NewConfigContainer()
-	err = cc.GetConfig()
-	if err != nil {
-		log.Printf("ERROR: parsing config files: %s\n", err)
 	}
 
 	// TODO: JFT We have the CMDline switches and config, now overwrite/append what's changed

--- a/internal/cmdline/cmdline.go
+++ b/internal/cmdline/cmdline.go
@@ -13,12 +13,12 @@ type CmdArgs struct {
 }
 
 // NewCmdArgs return the CmdArgs structure built from command line parameters.
-func NewCmdArgs() (*CmdArgs, error) {
+func NewCmdArgs(d uint, t uint) (*CmdArgs, error) {
 	c := new(CmdArgs)
 
 	c.Version = flag.Bool("v", false, "Display version")
-	c.HistDays = flag.Uint("d", 7, "Jobs history fetch last N days")
-	c.HistTimeout = flag.Uint("t", 30, "Job history fetch timeout, seconds")
+	c.HistDays = flag.Uint("d", d, "Jobs history fetch last N days")
+	c.HistTimeout = flag.Uint("t", t, "Job history fetch timeout, seconds")
 	flag.Parse()
 	if !flag.Parsed() {
 		return nil, errors.New("failed to parse command line flags")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,14 +32,6 @@ func (cc *ConfigContainer) GetTick() time.Duration {
 	return time.Duration(cc.Tick)
 }
 
-func (cc *ConfigContainer) GetHistDays() uint {
-	return cc.HistDays
-}
-
-func (cc *ConfigContainer) GetHistTimeout() uint {
-	return cc.HistTimeout
-}
-
 // Read & unmarshall configuration from 'name' file into configContainer structure
 func (cc *ConfigContainer) GetConfig() error {
 	var (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,8 @@ type ConfigContainer struct {
 	Prefix       string            // if this is set, then we prepend this path to all commands
 	Binpaths     map[string]string // else, we specify one by one
 	Tick         uint
+	HistDays     uint
+	HistTimeout  uint
 	TemplateDirs []string
 }
 
@@ -28,6 +30,14 @@ func NewConfigContainer() *ConfigContainer {
 
 func (cc *ConfigContainer) GetTick() time.Duration {
 	return time.Duration(cc.Tick)
+}
+
+func (cc *ConfigContainer) GetHistDays() uint {
+	return cc.HistDays
+}
+
+func (cc *ConfigContainer) GetHistTimeout() uint {
+	return cc.HistTimeout
 }
 
 // Read & unmarshall configuration from 'name' file into configContainer structure
@@ -81,6 +91,14 @@ func (cc *ConfigContainer) GetConfig() error {
 	if cc.Tick < defaults.TickMin {
 		// set default Tick
 		cc.Tick = defaults.TickMin
+	}
+	// if unset (==0), set to default
+	if cc.HistDays < 1 {
+	    cc.HistDays = defaults.HistDays
+	}
+	// if unset (==0), set to default
+	if cc.HistTimeout < 1 {
+	    cc.HistTimeout = defaults.HistTimeout
 	}
 	cc.testNsetBinPaths()
 	cc.testNsetTemplateDirs()

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -2,6 +2,8 @@ package defaults
 
 const (
 	TickMin = 3 // minimal time in seconds between that can be set in config file. If not set or less then, Set to this value.
+	HistDays = 7
+	HistTimeout = 30
 
 	AppName = "scom"
 

--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -53,6 +53,7 @@ A special thank you goes to:
 Seren Ümit
 Kilian Cavalotti
 Killian Murphy
+Hans-Nikolai Vießmann
 `
 
 	return s


### PR DESCRIPTION
Hi, just came across this project via SLURM-user mailing list. Really useful tool, thank you! For our cluster we're looking to add it. We'd like to by default have job history days and timeout set to different values.

With this PR we add entries to the scom.conf file to set new defaults for both job history query parameter days and command timeout. This allows changing the default value of these parameters while still allowing users to specify `-d` and `-t` flags.

Possibly being able to set (or pass) a `-S` args might also be worth exploring.